### PR TITLE
Add steps to create a generic path when installing from archive.

### DIFF
--- a/modules/proc-rhel-installing-jdk-archive.adoc
+++ b/modules/proc-rhel-installing-jdk-archive.adoc
@@ -3,25 +3,36 @@
 
 The Java Development Kit (JDK) can be manually installed using the {archive} bundle.
 This is useful if the Java administrator does not have root privileges on the system.
+Note that it's recommended to create a parent directory containing your JDKs and
+create a symlink to the latest JDK via a generic path. This eases upgrades to
+later versions.
+
 
 .Procedure
 . link:{openjdk-rhel-archive-download-url}[Download the JDK {archive} bundle] of {comp}.
 . Extract the contents of the {archive} bundle to a directory of your choice.
 +
 ----
+$ mdkir ~/jdks && cd ~/jdks
 $ tar -xf java-11-openjdk-11.0.3.7-0.tar.xz
 ----
 +
-. Add the `bin` directory contained in your {comp} installation path to the `PATH` environment variable:
+. Create a generic path by using symlinks to your JDK for easier upgrades
 +
 ----
-$ export PATH="/home/openjdk/java-11-openjdk-11.0.3.7-0.el6.static.jdk.openjdkportable.x86_64/bin"
+$ ln -s ~/jdks/java-11-openjdk-11.0.3.7-0.el6.static.jdk.openjdkportable.x86_64 ~/jdks/java-11
+----
++
+. Add the `bin` directory of the generic JDK path to the `PATH` environment variable:
++
+----
+$ export PATH="$PATH:$(echo ~)/jdks/java-11"
 ----
 +
 . Verify that `javac -version` works without supplying the full path:
 +
 ----
-$ java -version
+$ javac -version
 javac 11.0.3
 ----
 +

--- a/modules/proc-rhel-installing-jre-archive.adoc
+++ b/modules/proc-rhel-installing-jre-archive.adoc
@@ -1,8 +1,10 @@
 [id="rhel_installing_openjdk_jre_archive"]
-= Installing the JDK with the archive bundle on {rhel}
+= Installing the JRE with the archive bundle on {rhel}
 
 The Java Runtime Environment (JRE) can be manually installed using the {archive} bundle.
-This is useful if the Java administrator does not have root privileges on the system.
+This is useful if the Java administrator does not have root privileges on the system. Note that
+it's recommended to create a parent directory containing your JREs and create a symlink to the
+latest JRE via a generic path. This eases upgrades to later versions.
 
 .Procedure
 . link:{openjdk-rhel-archive-download-url}[Download the JRE {archive} bundle] of {comp}.
@@ -10,14 +12,22 @@ This is useful if the Java administrator does not have root privileges on the sy
 +
 [source,subs="+quotes"]
 ----
+$ mkdir ~/jres && cd ~/jres
 $ tar -xf _`<tar-file>`_
 ----
 +
-. Add the `bin` directory contained in your {comp} installation path to the `PATH` environment variable:
+. Create a generic path by using symlinks to your JRE for easier upgrades
 +
 [source,subs="+quotes"]
 ----
-$ export PATH="/home/openjdk/_`<your-directory>`_/bin"
+$ ln -s ~/jres/_`<your-directory>`_ ~/jres/_`<major-version>`_
+----
++
+. Add the `bin` directory of the generic JRE path to the `PATH` environment variable:
++
+[source,subs="+quotes"]
+----
+$ export PATH="$PATH:$(echo ~)/jres/_`<major-version>`_/bin"
 ----
 +
 . Verify that `java -version` works without supplying the full path:
@@ -36,4 +46,4 @@ OpenJDK 64-Bit Server VM (build 25.181.-b13, mixed mode)
 The `JAVA_HOME` environment variable must also be set to use some developer tools.
 Set the `JAVA_HOME` environment variable as follows:
 
-include::modules/proc-rhel-setting-java-home-env-variable.adoc[]
+include::proc-rhel-setting-java-home-env-variable.adoc[]


### PR DESCRIPTION
This is a suggestion to add a "generic" path via a symlink on installation, so that upgrades are going to be easier.